### PR TITLE
Added velocity and distance thresholds to ScrollSimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3
+
+- Various gratuitous changes. No new functionality.
+
 ## 0.1.2
 
 - Add BoundedFrictionSimulation

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/domokit/newton/badge.svg?branch=master)](https://coveralls.io/r/domokit/newton?branch=master)
 
 Simple Physics Simulations for Dart. Springs, friction, gravity, etc.
+
+To run the tests:
+pub get
+dart test/newton_test.dart

--- a/lib/src/scroll_simulation.dart
+++ b/lib/src/scroll_simulation.dart
@@ -8,23 +8,24 @@ part of newton;
 /// boundary. Friction is applied within the extends and a spring action applied
 /// at the boundaries. This simulation can only step forward.
 class ScrollSimulation extends SimulationGroup {
+  ScrollSimulation(
+    double position,
+    double velocity,
+    this._leadingExtent,
+    this._trailingExtent,
+    this._spring,
+    this._drag) {
+    _chooseSimulation(position, velocity, 0.0);
+  }
+
   final double _leadingExtent;
   final double _trailingExtent;
-  final SpringDescription _springDesc;
+  final SpringDescription _spring;
   final double _drag;
 
   bool _isSpringing = false;
   Simulation _currentSimulation;
   double _offset = 0.0;
-
-  ScrollSimulation(double position, double velocity, double leading,
-      double trailing, SpringDescription spring, double drag)
-      : _leadingExtent = leading,
-        _trailingExtent = trailing,
-        _springDesc = spring,
-        _drag = drag {
-    _chooseSimulation(position, velocity, 0.0);
-  }
 
   @override
   bool step(double time) => _chooseSimulation(
@@ -37,11 +38,8 @@ class ScrollSimulation extends SimulationGroup {
   @override
   double get currentIntervalOffset => _offset;
 
-  bool _chooseSimulation(
-      double position, double velocity, double intervalOffset) {
-
-    if (_springDesc == null &&
-        (position > _trailingExtent || position < _leadingExtent))
+  bool _chooseSimulation(double position, double velocity, double intervalOffset) {
+    if (_spring == null && (position > _trailingExtent || position < _leadingExtent))
       return false;
 
     /// This simulation can only step forward.
@@ -49,14 +47,12 @@ class ScrollSimulation extends SimulationGroup {
       if (position > _trailingExtent) {
         _isSpringing = true;
         _offset = intervalOffset;
-        _currentSimulation = new SpringSimulation(
-            _springDesc, position, _trailingExtent, velocity);
+        _currentSimulation = new SpringSimulation(_spring, position, _trailingExtent, velocity);
         return true;
       } else if (position < _leadingExtent) {
         _isSpringing = true;
         _offset = intervalOffset;
-        _currentSimulation = new SpringSimulation(
-            _springDesc, position, _leadingExtent, velocity);
+        _currentSimulation = new SpringSimulation(_spring, position, _leadingExtent, velocity);
         return true;
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: newton
 description: Simple Physics Simulations for Dart
-version: 0.1.2
+version: 0.1.3
 author: Chromium Authors <sky-dev@googlegroups.com>
 homepage: https://github.com/domokit/newton
 environment:

--- a/test/newton_test.dart
+++ b/test/newton_test.dart
@@ -168,7 +168,6 @@ void main() {
 
     var scroll =
         new ScrollSimulation(100.0, 400.0, 0.0, double.INFINITY, spring, 0.3);
-
     scroll.tolerance = const Tolerance(velocity: 1.0);
 
     expect(scroll.isDone(0.0), false);


### PR DESCRIPTION
Currently fling scrolls animate far to long after the display has effectively stopped moving. Added thresholds to ScrollSimulation so that a ScrollBehavior can configure when the simulation "isDone".

This change goes with https://github.com/flutter/engine/pull/1286