### PR TITLE
Added ScrollSpringSimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.5
+
+- Added ScrollSpringSimulation
+
 ## 0.1.4
 
 - Added FrictionSimulation.through()

--- a/lib/src/scroll_simulation.dart
+++ b/lib/src/scroll_simulation.dart
@@ -47,12 +47,12 @@ class ScrollSimulation extends SimulationGroup {
       if (position > _trailingExtent) {
         _isSpringing = true;
         _offset = intervalOffset;
-        _currentSimulation = new SpringSimulation(_spring, position, _trailingExtent, velocity);
+        _currentSimulation = new ScrollSpringSimulation(_spring, position, _trailingExtent, velocity);
         return true;
       } else if (position < _leadingExtent) {
         _isSpringing = true;
         _offset = intervalOffset;
-        _currentSimulation = new SpringSimulation(_spring, position, _leadingExtent, velocity);
+        _currentSimulation = new ScrollSpringSimulation(_spring, position, _leadingExtent, velocity);
         return true;
       }
     }

--- a/lib/src/simulation_group.dart
+++ b/lib/src/simulation_group.dart
@@ -41,7 +41,7 @@ abstract class SimulationGroup extends Simulation {
   @override
   bool isDone(double time) {
     _stepIfNecessary(time);
-    return currentSimulation.isDone(time);
+    return currentSimulation.isDone(time - currentIntervalOffset);
   }
 
   double _lastStep = -1.0;

--- a/lib/src/spring_simulation.dart
+++ b/lib/src/spring_simulation.dart
@@ -61,3 +61,23 @@ class SpringSimulation extends Simulation {
       _nearEqual(x(time), _endPosition, this.tolerance.distance) &&
           _nearZero(dx(time), this.tolerance.velocity);
 }
+
+/// A SpringSimulation where the value of x() is guaranteed to have exactly the
+/// end value when the simulation isDone().
+class ScrollSpringSimulation extends SpringSimulation {
+  ScrollSpringSimulation(SpringDescription desc, double start, double end, double velocity)
+    : super(desc, start, end, velocity);
+
+  bool _isDone(double position, double velocity) {
+    return _nearEqual(position, _endPosition, tolerance.distance) && _nearZero(velocity, tolerance.velocity);
+  }
+
+  @override
+  double x(double time) {
+    double xAtTime = super.x(time);
+    return _isDone(xAtTime, dx(time)) ? _endPosition : xAtTime;
+  }
+
+  @override
+  bool isDone(double time) => _isDone(x(time), dx(time));
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: newton
 description: Simple Physics Simulations for Dart
-version: 0.1.4
+version: 0.1.5
 author: Chromium Authors <sky-dev@googlegroups.com>
 homepage: https://github.com/domokit/newton
 environment:

--- a/test/newton_test.dart
+++ b/test/newton_test.dart
@@ -194,14 +194,16 @@ void main() {
         mass: 1.0, springConstant: 50.0, ratio: 0.5);
 
     var scroll = new ScrollSimulation(100.0, 800.0, 0.0, 300.0, spring, 0.3);
-
-    scroll.tolerance = const Tolerance(velocity: 0.01, distance: 0.01);
-
+    scroll.tolerance = const Tolerance(velocity: 0.5, distance: 0.1);
     expect(scroll.isDone(0.0), false);
+    expect(scroll.isDone(0.5), false); // switch from friction to spring
     expect(scroll.isDone(3.5), true);
 
     var scroll2 = new ScrollSimulation(100.0, -800.0, 0.0, 300.0, spring, 0.3);
-    expect(scroll2.isDone(4.5), true);
+    scroll2.tolerance = const Tolerance(velocity: 0.5, distance: 0.1);
+    expect(scroll2.isDone(0.0), false);
+    expect(scroll2.isDone(0.5), false); // switch from friction to spring
+    expect(scroll2.isDone(3.5), true);
   });
 
   test('scroll_with_inf_edge_ends', () {
@@ -228,5 +230,23 @@ void main() {
 
     // We should never switch
     expect(scroll.currentIntervalOffset, 0.0);
+  });
+
+  test('over/under scroll spring', () {
+    var spring = new SpringDescription.withDampingRatio(mass: 1.0, springConstant: 170.0, ratio: 1.1);
+    var scroll = new ScrollSimulation(500.0, -7500.0, 0.0, 1000.0, spring, 0.025);
+    scroll.tolerance = new Tolerance(velocity: 45.0, distance: 1.5);
+
+    expect(scroll.isDone(0.0), false);
+    expect(scroll.x(0.0), closeTo(500.0, .0001));
+    expect(scroll.dx(0.0), closeTo(-7500.0, .0001));
+
+    expect(scroll.isDone(0.025), false);
+    expect(scroll.x(0.025), closeTo(320.0, 1.0));
+    expect(scroll.dx(0.25), closeTo(-2982, 1.0));
+
+    expect(scroll.isDone(2.0), true);
+    expect(scroll.x(2.0), 0.0);
+    expect(scroll.dx(2.0), closeTo(0.0, 45.0));
   });
 }


### PR DESCRIPTION
The ScrollSimulation uses ScrollSpringSimulation for over/under scroll so that the simulation ends at exactly the leading or trailing extent value

This is part of the fix for https://github.com/flutter/engine/issues/1568
